### PR TITLE
Store CAN Fwd and CAN ID in settings

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -19,11 +19,12 @@
 
 #include "commands.h"
 #include <QDebug>
+#include <QSettings>
 
 Commands::Commands(QObject *parent) : QObject(parent)
 {
-    mSendCan = false;
-    mCanId = 0;
+    mSendCan = QSettings().value("send_can", false).toBool();
+    mCanId = QSettings().value("can_id", 0).toInt();
     mIsLimitedMode = false;
 
     // Firmware state
@@ -63,9 +64,10 @@ bool Commands::isLimitedMode()
 void Commands::setSendCan(bool sendCan, int id)
 {
     mSendCan = sendCan;
+    QSettings().setValue("send_can", sendCan);
 
     if (id >= 0) {
-        mCanId = id;
+        setCanSendId(id);
     }
 }
 
@@ -77,6 +79,7 @@ bool Commands::getSendCan()
 void Commands::setCanSendId(unsigned int id)
 {
     mCanId = id;
+    QSettings().setValue("can_id", id);
 }
 
 int Commands::getCanSendId()


### PR DESCRIPTION
Since some people like me might prefer to always connect via VESC, it would be nice to save CAN ID in settings and not to change it every time on startup. I thought it could be a cool little thing.